### PR TITLE
Pull changes from 0.7.6 Ruler.measure()

### DIFF
--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -70,7 +70,7 @@ Ruler.prototype.measure = function(destination, {gridSpaces=true}={}) {
       const origin = waypoints[i];
       const label = this.labels.children[i];
       const ray = new Ray(origin, dest);
-      if ( ray.distance < (0.2 * canvas.grid.size) ) {
+      if ( ray.distance < 10 ) {
         if ( label ) label.visible = false;
         continue;
       }
@@ -89,7 +89,7 @@ Ruler.prototype.measure = function(destination, {gridSpaces=true}={}) {
     }
 
     // Clear the grid highlight layer
-    const hlt = canvas.grid.highlightLayers[this.name];
+    const hlt = canvas.grid.highlightLayers[this.name] || canvas.grid.addHighlightLayer(this.name);
     hlt.clear();
 
     // Draw measured path


### PR DESCRIPTION
In FoundryVTT 0.7.6, changes were made to the ruler which caused an
exception. This has been tested for compatibility with 0.7.5, but not
any earlier versions, though the changes should work on earlier versions
as well.