### PR TITLE
[WIP] Make module compatible with Drag Ruler

### DIFF
--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -33,6 +33,10 @@ Ruler.prototype._addWaypoint = function(point) {
   this.labels.addChild(new PIXI.Text("", CONFIG.canvasTextStyle));
 }
 
+window.findMovementToken = findMovementToken
+window.getEvenSnappingFlag = getEvenSnappingFlag
+window.findVertexSnapPoint = findVertexSnapPoint
+
 
 //overwrite measure to recalculate the location that ruler is going to move the token to, handling alt snapping stuff
 Ruler.prototype.measure = function(destination, {gridSpaces=true}={}) {


### PR DESCRIPTION
Hex Size Support currently is incompatible with Drag Ruler (a new plugin I wrote that aims to replace Show Drag Distance, which was abandoned by it's maintainer). The incompatibility stems from the fact that we both modify the `Ruler.measure` function.

Drag Ruler doesn't do this modification statically, but instead patches the code of the measure function at runtime. This has the advantage that it's able to insert it's changes even if another module slightly altered the measure function as well. As a result our modules are able to work together in theory (since the patches we do don't conflict with each other).

However this fails because the function that Drag Ruler patched is being executed in the global scope and some of the functions Hex Size Support uses (`findMovementToken`, `getEvenSnappingFlag` and `findVertexSnapPoint`) aren't available in the global scope.

This proof of concept patch exposes those functions to global scope and proves this way, that our modules can indeed co-exist. The question now is how we go forward with this. The easiest route would be to simply merge my proof of concept patch. However I feel like this wouldn't be very clean (as the functions could collide with functions other modules might introduce into global space or with functions provided by future versions of foundry). This could be solved by putting them in some namespace that's unlikely to collide (like `hexTokenSupport`). Or maybe you have an entirely better idea how we could reach compatibility between our modules.