### PR TITLE
Expose getEvenSnappingFlag for use in external modules

### DIFF
--- a/modules/hooks.js
+++ b/modules/hooks.js
@@ -29,6 +29,7 @@ Hooks.once("ready", async function(){
     CONFIG.hexSizeSupport.getAltSnappingFlag = getAltSnappingFlag
     CONFIG.hexSizeSupport.getAltOrientationFlag = getAltOrientationFlag
     CONFIG.hexSizeSupport.getCenterOffset = getCenterOffset
+    CONFIG.hexSizeSupport.getEvenSnappingFlag = getEvenSnappingFlag
 
 
     document.addEventListener("keydown", function(event){


### PR DESCRIPTION
I need to use `getEvenSnappingFlag` to make the Terrain Ruler module compatible with Hex Size Support.

Since it was already included in the imports I think you intended to do that already in 39600e9b, but it somehow slipped through.