### PR TITLE
0.8.x support

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "author": "Ourobor",
   "version": "0.5.5",
   "minimumCoreVersion": "0.6.0",
-  "compatibleCoreVersion": "0.7.8",
+  "compatibleCoreVersion": "0.8.6",
   "esmodules": [
   	"modules/hooks.js",
     "modules/ruler-changes.js",

--- a/modules/hex-token-config.js
+++ b/modules/hex-token-config.js
@@ -275,9 +275,9 @@ export class HexTokenConfig extends FormApplication {
 	async _updateObject(event, formData) {
 		let token = this.object;
 		let updateData = {
-				scale: formData.scale.toString(), 
-				height: token.data.height.toString(), 
-				width: token.data.width.toString()
+				scale: formData.scale, 
+				height: token.data.height, 
+				width: token.data.width
 		};
 
 

--- a/modules/hex-token-config.js
+++ b/modules/hex-token-config.js
@@ -149,12 +149,6 @@ export class HexTokenConfig extends FormApplication {
 
 
 	  	this.object.data.tempHexValues.borderSize = border;
-
-	  	let locked = this.object.data.tempHexValues.locked;
-	  	this.object.data.tempHexValues.locked = undefined;
-	  	this.object.shiftPosition(0,0);
-	  	this.object.data.tempHexValues.locked = locked
-	  	// this.object.refresh();
   	}
   	this._updateFlagCheckboxes()
 

--- a/modules/hooks.js
+++ b/modules/hooks.js
@@ -8,7 +8,10 @@ Hooks.once('init', async function(){
 
 //Add the hex config button to the token hud
 Hooks.on("renderTokenHUD", async (app, html, token) => {
-		const configButton = html.find('.config');
+		configButton = html.find('[data-action="config"]').first();
+		if (configButton == null) {
+			configButton = html.find('.config')
+		}
 		configButton.after($(`
 		<div class="control-icon config" id="hexConfig">
            	<img src="modules/hex-size-support/assets/hexIcon.svg" style="display: block; margin-left: auto; margin-right: auto;"/>

--- a/modules/hooks.js
+++ b/modules/hooks.js
@@ -8,9 +8,9 @@ Hooks.once('init', async function(){
 
 //Add the hex config button to the token hud
 Hooks.on("renderTokenHUD", async (app, html, token) => {
-		configButton = html.find('[data-action="config"]').first();
-		if (configButton == null) {
-			configButton = html.find('.config')
+		var configButton = html.find('[data-action="config"]').first();
+		if (configButton === null) {
+			configButton = html.find('.config');
 		}
 		configButton.after($(`
 		<div class="control-icon config" id="hexConfig">

--- a/modules/token-changes.js
+++ b/modules/token-changes.js
@@ -110,8 +110,9 @@ Token.prototype.refresh = (function () {
 
 //overwrite the left click drop handling to snap the token correctly when you release dragging the token
 Token.prototype._cachedonDragLeftDrop = Token.prototype._onDragLeftDrop;
-Token.prototype._onDragLeftDrop = function(event) {
 
+Token.prototype._onDragLeftDrop = function(event) {
+	// console.log(Token.prototype._cachedonDragLeftDrop)
 	let altSnapping = getAltSnappingFlag(this)
 
 	if(altSnapping == true){
@@ -120,7 +121,7 @@ Token.prototype._onDragLeftDrop = function(event) {
 		const preview = game.settings.get("core", "tokenDragPreview");
 
 	    // Ensure the destination is within bounds
-	    if ( !canvas.grid.hitArea.contains(destination.x, destination.y) ) return false;
+	    if (!canvas.grid.hitArea.contains(destination.x, destination.y) ) return false;
 
 	    // Compute the final dropped positions
 	    const updates = clones.reduce((updates, c) => {
@@ -131,7 +132,7 @@ Token.prototype._onDragLeftDrop = function(event) {
 	    	let dest = {x: c.data.x, y: c.data.y};
 
 	    	//only enabling snapping when shift isn't held
-	    	if (!originalEvent.shiftKey) {
+	    	if (!originalEvent.shiftKey && (canvas.grid.type !== CONST.GRID_TYPES.GRIDLES)) {
 		      	let evenSnapping = getEvenSnappingFlag(this);
 
 		      	let offset = getCenterOffset(this)
@@ -165,7 +166,7 @@ Token.prototype._onDragLeftDrop = function(event) {
 	      updates.push({_id: c._original.id, x: dest.x, y: dest.y});
 	      return updates;
 	    }, []);
-	    return canvas.scene.updateEmbeddedEntity(this.constructor.name, updates);
+	    return canvas.scene.updateEmbeddedDocuments("Token", updates);
 	}
 	else {
 		this._cachedonDragLeftDrop(event);


### PR DESCRIPTION
This patch works for me for 0.8.6. I have not tested it on other versions. It looks like the the way to find the config button was changed and so I changed the find function but it should default to the old method if it found nothing so it should be backwards compatible.