### PR TITLE
libRuler compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -12,6 +12,13 @@
     "modules/helpers.js",
     "modules/token-changes.js"
   ],
+  
+  "dependencies": [
+    {
+      "name": "lib-wrapper",
+      "manifest": "https://raw.githubusercontent.com/ruipin/fvtt-lib-wrapper/master/module.json"
+    }],
+  
   "url": "https://github.com/Ourobor/Hex-Size-Support",
   "manifest": "https://raw.githubusercontent.com/Ourobor/Hex-Size-Support/1.1.0/module.json",
   "download": "https://github.com/Ourobor/Hex-Size-Support/archive/refs/tags/1.1.0.zip"

--- a/module.json
+++ b/module.json
@@ -17,6 +17,11 @@
     {
       "name": "lib-wrapper",
       "manifest": "https://raw.githubusercontent.com/ruipin/fvtt-lib-wrapper/master/module.json"
+    },
+    
+    {
+      "name": "libruler",
+      "manifest": "https://github.com/caewok/fvtt-lib-ruler/releases/latest/download/module.json"
     }],
   
   "url": "https://github.com/Ourobor/Hex-Size-Support",

--- a/modules/hooks.js
+++ b/modules/hooks.js
@@ -1,5 +1,6 @@
 import { HexTokenConfig } from './hex-token-config.js'
 import { findVertexSnapPoint, findMovementToken, getEvenSnappingFlag, getAltSnappingFlag, getAltOrientationFlag, getCenterOffset } from './helpers.js'
+import { registerHexRulerPatches } from "./patching.js";
 
 //load in the hex token config's html template
 Hooks.once('init', async function(){
@@ -48,6 +49,11 @@ Hooks.once("ready", async function(){
         }
     });
 })
+
+Hooks.once('libRulerReady', async function() {
+  registerHexRulerPatches();
+});
+
 
 /**
 My sincerest affection and love for the Pilot NET Discord community. Without your support, patience and good feels I wouldn't have 

--- a/modules/patching.js
+++ b/modules/patching.js
@@ -2,9 +2,9 @@ import {HexSizeSupportAddWaypoint, HexSizeSupportMeasure, HexSizeSupportAnimateT
 
 const MODULE_ID = "hex-size-support";
 
-export function registerLibRuler() {
-  libwrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', HexSizeSupportAddWaypoint, 'WRAPPER');
-  libwrapper.register(MODULE_ID, 'Ruler.prototype.measure', HexSizeSupportMeasure, 'WRAPPER');
+export function registerHexRulerPatches() {
+  libWrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', HexSizeSupportAddWaypoint, 'WRAPPER');
+  libWrapper.register(MODULE_ID, 'Ruler.prototype.measure', HexSizeSupportMeasure, 'WRAPPER');
 
   // The animateToken method is added by libRuler module
   libWrapper.register(MODULE_ID, 'Ruler.prototype.animateToken', HexSizeSupportAnimateToken, 'WRAPPER');

--- a/modules/patching.js
+++ b/modules/patching.js
@@ -4,4 +4,5 @@ const MODULE_ID = "hex-size-support";
 
 export function registerLibRuler() {
   libwrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', HexSizeSupportAddWaypoint, 'WRAPPER');
+  libwrapper.register(MODULE_ID, 'Ruler.prototype.measure', HexSizeSupportMeasure, 'WRAPPER');
 }

--- a/modules/patching.js
+++ b/modules/patching.js
@@ -1,0 +1,7 @@
+import {HexSizeSupportAddWaypoint, HexSizeSupportMeasure} from "./ruler-changes.js";
+
+const MODULE_ID = "hex-size-support";
+
+export function registerLibRuler() {
+  libwrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', HexSizeSupportAddWaypoint, 'WRAPPER');
+}

--- a/modules/patching.js
+++ b/modules/patching.js
@@ -1,8 +1,11 @@
-import {HexSizeSupportAddWaypoint, HexSizeSupportMeasure} from "./ruler-changes.js";
+import {HexSizeSupportAddWaypoint, HexSizeSupportMeasure, HexSizeSupportAnimateToken} from "./ruler-changes.js";
 
 const MODULE_ID = "hex-size-support";
 
 export function registerLibRuler() {
   libwrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', HexSizeSupportAddWaypoint, 'WRAPPER');
   libwrapper.register(MODULE_ID, 'Ruler.prototype.measure', HexSizeSupportMeasure, 'WRAPPER');
+
+  // The animateToken method is added by libRuler module
+  libWrapper.register(MODULE_ID, 'Ruler.prototype.animateToken', HexSizeSupportAnimateToken, 'WRAPPER');
 }

--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -1,33 +1,42 @@
 import { findMovementToken, findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag } from './helpers.js'
 
 //TODO rewrite this to only run my new stuff if needed
-Ruler.prototype._addWaypoint = function(point) {
-  let center = canvas.grid.getCenter(point.x, point.y);
+HexSizeSupportAddWaypoint = function(wrapped, point) {
+  // If not on a hex grid, can just return normally.
+  // Otherwise, modify the waypoint and return
+  if(canvas.grid.type === CONST.GRID_TYPES.HEXODDR || 
+     canvas.grid.type === CONST.GRID_TYPES.HEXEVENR ||
+     canvas.grid.type === CONST.GRID_TYPES.HEXODDQ ||
+     canvas.grid.type === CONST.GRID_TYPES.HEXEVENQ) {
+     
+    let center = canvas.grid.getCenter(point.x, point.y);
 
-	//retrieve the token this ruler is measure from if possible
-	let token;
-	if(this.waypoints.length == 0){
-		token = findMovementToken(point.x,point.y);
-	}
-	else{
-		token = findMovementToken(this.waypoints[0].x,this.waypoints[0].y);	
-	}
-
-  //if there is a token under the selected point, check for even/odd
-  if(token != undefined){
-    let evenSnapping = getEvenSnappingFlag(token)
-
-    //if the even snapping flag is set, we need to offset the position of the first waypoint to a vertex
-    if(evenSnapping){
-
-      //get the new center location for the ruler
-      let newPoints = findVertexSnapPoint(point.x, point.y, token, canvas.grid.grid)
-
-    	//update the center
-    	center[0] = newPoints.x;
-    	center[1] = newPoints.y;
-      
+    //retrieve the token this ruler is measure from if possible
+    let token;
+    if(this.waypoints.length == 0){
+      token = findMovementToken(point.x,point.y);
     }
+    else{
+      token = findMovementToken(this.waypoints[0].x,this.waypoints[0].y);	
+    }
+
+    //if there is a token under the selected point, check for even/odd
+    if(token != undefined){
+      let evenSnapping = getEvenSnappingFlag(token)
+
+      //if the even snapping flag is set, we need to offset the position of the first waypoint to a vertex
+      if(evenSnapping){
+
+        //get the new center location for the ruler
+        let newPoints = findVertexSnapPoint(point.x, point.y, token, canvas.grid.grid)
+
+        //update the center
+        point.x = newPoints.x;
+        point.y = newPoints.y
+      }
+    }
+     
+  } 
   }
   this.waypoints.push(new PIXI.Point(center[0], center[1]));
   this.labels.addChild(new PIXI.Text("", CONFIG.canvasTextStyle));

--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -1,7 +1,7 @@
 import { findMovementToken, findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag } from './helpers.js'
 
 //TODO rewrite this to only run my new stuff if needed
-HexSizeSupportAddWaypoint = function(wrapped, point) {
+export function HexSizeSupportAddWaypoint(wrapped, point) {
   // If not on a hex grid, can just return normally.
   // Otherwise, modify the waypoint and return
   if(canvas.grid.type === CONST.GRID_TYPES.HEXODDR || 
@@ -43,7 +43,7 @@ HexSizeSupportAddWaypoint = function(wrapped, point) {
 
 
 //overwrite measure to recalculate the location that ruler is going to move the token to, handling alt snapping stuff
-HexSizeSupportMeasure = function(wrapped, destination, {gridSpaces=true}={}) {
+export function HexSizeSupportMeasure(wrapped, destination, {gridSpaces=true}={}) {
   // If not on a hex grid, can just return normally.
   // Otherwise, modify the destination and return
   if(canvas.grid.type === CONST.GRID_TYPES.HEXODDR || 
@@ -70,7 +70,7 @@ HexSizeSupportMeasure = function(wrapped, destination, {gridSpaces=true}={}) {
     }  
   }
   
-  return wrapped(destination, {gridSpaces = gridSpaces});
+  return wrapped(destination, {gridSpaces: gridSpaces});
 }
   
 /* Wrap the libRuler animateToken method
@@ -82,7 +82,7 @@ HexSizeSupportMeasure = function(wrapped, destination, {gridSpaces=true}={}) {
  * @param {number} dy Offset in y direction relative to the Token top-left.
  * @param {integer} segment_num The segment number, where 1 is the
  */
-HexSizeSupportAnimateToken = async function(wrapped, token, ray, dx, dy, segment_num) {
+export async function HexSizeSupportAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
   // If not on a hex grid, can just return normally.
   // Otherwise, modify the waypoint and return
   const offset = {x: 0, y: 0};

--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -85,6 +85,8 @@ export function HexSizeSupportMeasure(wrapped, destination, {gridSpaces=true}={}
 export async function HexSizeSupportAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
   // If not on a hex grid, can just return normally.
   // Otherwise, modify the waypoint and return
+  console.log(`HexSize Animate Token`);
+
   const offset = {x: 0, y: 0};
   
   if(canvas.grid.type === CONST.GRID_TYPES.HEXODDR || 
@@ -100,7 +102,8 @@ export async function HexSizeSupportAnimateToken(wrapped, token, ray, dx, dy, se
 				  y: (token.h) / 2
 		    }
      }  
+    console.log(`HexSize|Offsetting ${offset.x}, ${offset.y}`);
   }
   
-  return wrapped(token, ray, dx - offset.x, dy - offset.y, segment_num);
+  return wrapped(token, ray, dx - offset.x, dy + offset.y, segment_num);
 }

--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -85,7 +85,7 @@ export function HexSizeSupportMeasure(wrapped, destination, {gridSpaces=true}={}
 export async function HexSizeSupportAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
   // If not on a hex grid, can just return normally.
   // Otherwise, modify the waypoint and return
-  console.log(`HexSize Animate Token ${token.id} with dx/dy ${dx}, {dy}`);
+  // console.log(`HexSize Animate Token ${token.id} with dx/dy ${dx}, {dy}`);
 
   if(canvas.grid.type === CONST.GRID_TYPES.HEXODDR ||
      canvas.grid.type === CONST.GRID_TYPES.HEXEVENR ||
@@ -109,7 +109,7 @@ export async function HexSizeSupportAnimateToken(wrapped, token, ray, dx, dy, se
        dx = ray.B.x - offset.x - old_dest[0];
        dy = ray.B.y - offset.y - old_dest[1];
 
-       console.log(`HexSize|Offsetting ${offset.x}, ${offset.y}; dx/dy ${dx}, ${dy}`);
+       //console.log(`HexSize|Offsetting ${offset.x}, ${offset.y}; dx/dy ${dx}, ${dy}`);
     }
   }
 


### PR DESCRIPTION
Hi! This pull request takes advantage of [libWrapper](https://github.com/ruipin/fvtt-lib-wrapper) and [libRuler](https://github.com/caewok/fvtt-lib-ruler), which should hopefully make your job easier when dealing with the ruler measurements for Hex Size Support. I, along with Stäbchenfisch#5107, developed libRuler to make it easier for modules to interact when dealing with the Foundry Ruler code. 

As you noted in your code, Ruler.measure is a large function, and you modified very little of it! So my proposed changes instead use libWrapper to "wrap" the three functions you modified: Ruler.prototype._addWaypoint, Ruler.prototype.measure, and Ruler.prototype.animateToken. The third is a sub-function added by libRuler to handle token animation within Ruler.prototype.moveToken. You will see that the actual important parts of ruler-changes.js have been cut down substantially by doing this. 

I tested this out, and I think I have the basics working.  The animateToken part is a little bit tricky, and I am not overly familiar with Hex Size Support. So please let me know if you have questions or issues, and I will see if I can resolve them. You can test this out with just libRuler and libWrapper, or you can also run this alongside [Elevation Ruler](https://github.com/caewok/fvtt-elevation-ruler) (my other module that depends on libRuler to see how the modules interact. 

I should note that Stäbchenfisch#5107 is working on libRuler compatibility for Drag Ruler and Terrain Ruler, and ensuring both play nicely with Hex Size Support is a big part of that. So this would help his modules out as well. Thanks for considering this!