### PR TITLE
Skip token changes on non-hex maps

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "author": "Ourobor",
   "version": "1.1.0",
   "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "0.8.6",
+  "compatibleCoreVersion": "0.8.9",
   "esmodules": [
     "modules/hooks.js",
     "modules/ruler-changes.js",

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -84,10 +84,6 @@ export function getAltOrientationFlag(token){
     return altOrientation;
 }
 
-export function isHexGrid() {
-	return ![CONST.GRID_TYPES.GRIDLESS, CONST.GRID_TYPES.SQUARE].includes(canvas.grid.type);
-}
-
 /**
  * Calculates the offset between the top left of a token and its center
  * @param (Token) token the token to calculate the offset of

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -84,6 +84,10 @@ export function getAltOrientationFlag(token){
     return altOrientation;
 }
 
+export function isHexGrid() {
+	return ![CONST.GRID_TYPES.GRIDLESS, CONST.GRID_TYPES.SQUARE].includes(canvas.grid.type);
+}
+
 /**
  * Calculates the offset between the top left of a token and its center
  * @param (Token) token the token to calculate the offset of

--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -1,4 +1,4 @@
-import { findMovementToken, findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag } from './helpers.js'
+import { findMovementToken, findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag, isHexGrid } from './helpers.js'
 
 //TODO rewrite this to only run my new stuff if needed
 Ruler.prototype._addWaypoint = function(point) {
@@ -14,7 +14,7 @@ Ruler.prototype._addWaypoint = function(point) {
 	}
 
   //if there is a token under the selected point, check for even/odd
-  if(token != undefined){
+  if(token != undefined && isHexGrid()){
     let evenSnapping = getEvenSnappingFlag(token)
 
     //if the even snapping flag is set, we need to offset the position of the first waypoint to a vertex
@@ -40,7 +40,7 @@ Ruler.prototype.measure = function(destination, {gridSpaces=true}={}) {
     let center = canvas.grid.getCenter(destination.x, destination.y);
 
     let evenSnapping;
-    if(token != undefined){
+    if(token != undefined && isHexGrid()){
       evenSnapping = getEvenSnappingFlag(token)
     }
     //determine if this is measuring from an even token; even tokens need to have their snapping points offset
@@ -127,7 +127,7 @@ Ruler.prototype.moveToken = async function() {
     let altSnapping = getAltSnappingFlag(token)
     
     //if using alt snapping, just put the center of the token to the waypoint 
-    if(token != undefined && altSnapping){
+    if(token != undefined && altSnapping && isHexGrid()){
   		let wasPaused = game.paused;
   		if ( wasPaused && !game.user.isGM ) {
         ui.notifications.warn(game.i18n.localize("GAME.PausedWarning"));

--- a/modules/ruler-changes.js
+++ b/modules/ruler-changes.js
@@ -1,4 +1,4 @@
-import { findMovementToken, findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag, isHexGrid } from './helpers.js'
+import { findMovementToken, findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag } from './helpers.js'
 
 //TODO rewrite this to only run my new stuff if needed
 Ruler.prototype._addWaypoint = function(point) {
@@ -14,7 +14,7 @@ Ruler.prototype._addWaypoint = function(point) {
 	}
 
   //if there is a token under the selected point, check for even/odd
-  if(token != undefined && isHexGrid()){
+  if(token != undefined && canvas.grid?.isHex){
     let evenSnapping = getEvenSnappingFlag(token)
 
     //if the even snapping flag is set, we need to offset the position of the first waypoint to a vertex
@@ -40,7 +40,7 @@ Ruler.prototype.measure = function(destination, {gridSpaces=true}={}) {
     let center = canvas.grid.getCenter(destination.x, destination.y);
 
     let evenSnapping;
-    if(token != undefined && isHexGrid()){
+    if(token != undefined && canvas.grid?.isHex){
       evenSnapping = getEvenSnappingFlag(token)
     }
     //determine if this is measuring from an even token; even tokens need to have their snapping points offset
@@ -127,7 +127,7 @@ Ruler.prototype.moveToken = async function() {
     let altSnapping = getAltSnappingFlag(token)
     
     //if using alt snapping, just put the center of the token to the waypoint 
-    if(token != undefined && altSnapping && isHexGrid()){
+    if(token != undefined && altSnapping && canvas.grid?.isHex){
   		let wasPaused = game.paused;
   		if ( wasPaused && !game.user.isGM ) {
         ui.notifications.warn(game.i18n.localize("GAME.PausedWarning"));

--- a/modules/token-changes.js
+++ b/modules/token-changes.js
@@ -1,4 +1,4 @@
-import { findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag, getAltOrientationFlag, getCenterOffset, isHexGrid } from './helpers.js'
+import { findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag, getAltOrientationFlag, getCenterOffset } from './helpers.js'
 import { borderData } from './token-border-config.js'
 
 //we intercept refresh method(questionably) to set the pivot of the token correctly
@@ -18,7 +18,7 @@ Token.prototype.refresh = (function () {
 
 		//execute existing refresh function
 		const p = cached.apply(this, arguments);
-		if (!isHexGrid()) return p;
+		if (!canvas.grid?.isHex) return p;
 
 		//Now handle rewriting the border if needed
 
@@ -114,7 +114,7 @@ Token.prototype._cachedonDragLeftDrop = Token.prototype._onDragLeftDrop;
 Token.prototype._onDragLeftDrop = function(event) {
 	let altSnapping = getAltSnappingFlag(this)
 
-	if(altSnapping == true && isHexGrid()){
+	if(altSnapping == true && canvas.grid?.isHex){
 		const clones = event.data.clones || [];
 	    const {originalEvent, destination} = event.data;
 		const preview = game.settings.get("core", "tokenDragPreview");
@@ -183,7 +183,7 @@ Token.prototype._getShiftedPosition = function(dx, dy){
 	let altSnapping = getAltSnappingFlag(this)
 
 	//run original code if no flag for alt-snapping
-	if(!altSnapping == true || !isHexGrid()){
+	if(!altSnapping == true || !canvas.grid?.isHex){
 		return this._getShiftedPositionCached(dx,dy);
 	}
 	else{

--- a/modules/token-changes.js
+++ b/modules/token-changes.js
@@ -1,4 +1,4 @@
-import { findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag, getAltOrientationFlag, getCenterOffset } from './helpers.js'
+import { findVertexSnapPoint, getAltSnappingFlag, getEvenSnappingFlag, getAltOrientationFlag, getCenterOffset, isHexGrid } from './helpers.js'
 import { borderData } from './token-border-config.js'
 
 //we intercept refresh method(questionably) to set the pivot of the token correctly
@@ -18,6 +18,7 @@ Token.prototype.refresh = (function () {
 
 		//execute existing refresh function
 		const p = cached.apply(this, arguments);
+		if (!isHexGrid()) return p;
 
 		//Now handle rewriting the border if needed
 
@@ -113,7 +114,7 @@ Token.prototype._cachedonDragLeftDrop = Token.prototype._onDragLeftDrop;
 Token.prototype._onDragLeftDrop = function(event) {
 	let altSnapping = getAltSnappingFlag(this)
 
-	if(altSnapping == true){
+	if(altSnapping == true && isHexGrid()){
 		const clones = event.data.clones || [];
 	    const {originalEvent, destination} = event.data;
 		const preview = game.settings.get("core", "tokenDragPreview");
@@ -182,7 +183,7 @@ Token.prototype._getShiftedPosition = function(dx, dy){
 	let altSnapping = getAltSnappingFlag(this)
 
 	//run original code if no flag for alt-snapping
-	if(!altSnapping == true){
+	if(!altSnapping == true || !isHexGrid()){
 		return this._getShiftedPositionCached(dx,dy);
 	}
 	else{


### PR DESCRIPTION
This skips token changes and goes back to the default settings for
gridless and square maps since it doesn't make sense to apply the
changes there.
